### PR TITLE
Don't strip characters that match the first codepoints in multi-codepoint emoji in Rumoji.encode_io

### DIFF
--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -27,7 +27,9 @@ module Rumoji
 
       sequence =  if last_emoji.nil? || !last_emoji.codepoints.include?(codepoint)
                     if possible_emoji.empty?
-                      [codepoint].pack("U")
+                      last_codepoint = last_emoji && last_emoji.codepoints.first
+                      sequence_codepoints = [last_codepoint, codepoint].compact
+                      sequence_codepoints.pack("U" * sequence_codepoints.size)
                     else
                       multiple_codepoint_emoji = possible_emoji.select(&:multiple?)
                       if multiple_codepoint_emoji.empty?

--- a/spec/rumoji_spec.rb
+++ b/spec/rumoji_spec.rb
@@ -30,6 +30,13 @@ describe Rumoji do
       Rumoji.encode_io(io).string.must_equal ":smile:"
     end
 
+    it "keeps codepoints that match the beginnings of multi-codepoint emoji" do
+      text = "i like #hashtags and 1direction"
+      io   = StringIO.new(text)
+
+      Rumoji.encode_io(io).string.must_equal text
+    end
+
     describe "with multiple codepoints" do
       it "transforms a stream" do
         io1 = StringIO.new("#{@zero}")


### PR DESCRIPTION
Running `Rumoji.encode_io` on a stream with characters that match the first codepoints in multi-codepoint emoji causes those characters to get stripped:

``` ruby
io = StringIO.new("i like #hashtags and 1direction")
Rumoji.encode_io(io).string
# => "i like hashtags and direction"
```

This branch fixes it.
