### PR TITLE
Handle multiple possible emoji in a row

### DIFF
--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -26,7 +26,7 @@ module Rumoji
       last_emoji = previous_emoji.pop
 
       sequence =  if last_emoji.nil? || !last_emoji.codepoints.include?(codepoint)
-                    if possible_emoji.empty?
+                    if possible_emoji.empty? || last_emoji
                       last_codepoint = last_emoji && last_emoji.codepoints.first
                       sequence_codepoints = [last_codepoint, codepoint].compact
                       sequence_codepoints.pack("U" * sequence_codepoints.size)

--- a/spec/rumoji_spec.rb
+++ b/spec/rumoji_spec.rb
@@ -31,7 +31,7 @@ describe Rumoji do
     end
 
     it "keeps codepoints that match the beginnings of multi-codepoint emoji" do
-      text = "i like #hashtags and 1direction"
+      text = "i like #hashtags and 1direction they are the #1 band"
       io   = StringIO.new(text)
 
       Rumoji.encode_io(io).string.must_equal text


### PR DESCRIPTION
Currently, if there are two possible emoji in a row, the first one is stripped:

``` ruby
io = StringIO.new("i like #hashtags and 1direction they are the #1 band")
Rumoji.encode_io(io).string
# actual:   => "i like #hashtags and 1direction they are the 1 band"
# expected: => "i like #hashtags and 1direction they are the #1 band"
```

This branch fixes it.
