### PR TITLE
Handle some edge cases with "possible emoji"

### DIFF
--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -28,8 +28,7 @@ module Rumoji
       sequence =  if last_emoji.nil? || !last_emoji.codepoints.include?(codepoint)
                     if possible_emoji.empty? || last_emoji
                       last_codepoint = last_emoji && last_emoji.codepoints.first
-                      sequence_codepoints = [last_codepoint, codepoint].compact
-                      sequence_codepoints.pack("U" * sequence_codepoints.size)
+                      sequence_from_codepoints(last_codepoint, codepoint)
                     else
                       multiple_codepoint_emoji = possible_emoji.select(&:multiple?)
                       if multiple_codepoint_emoji.empty?
@@ -44,6 +43,14 @@ module Rumoji
 
       writer.write sequence
     end
+
+    # If the last character was the beginning of a possible emoji, tack the
+    # first codepoint onto the end.
+    if last_emoji = previous_emoji.pop
+      writeable.write sequence_from_codepoints(last_emoji.codepoints.first)
+    end
+
+    writeable
   end
 
   def decode_io(readable, writeable=StringIO.new(""))
@@ -55,5 +62,9 @@ module Rumoji
 
 private
 
+  def sequence_from_codepoints(*codepoints)
+    compacted = codepoints.flatten.compact
+    compacted.pack("U" * compacted.size)
+  end
 
 end

--- a/spec/rumoji_spec.rb
+++ b/spec/rumoji_spec.rb
@@ -31,7 +31,7 @@ describe Rumoji do
     end
 
     it "keeps codepoints that match the beginnings of multi-codepoint emoji" do
-      text = "i like #hashtags and 1direction they are the #1 band"
+      text = "i like #hashtags and 1direction they are the #1 band. end with 9"
       io   = StringIO.new(text)
 
       Rumoji.encode_io(io).string.must_equal text


### PR DESCRIPTION
Two small edge cases with possible emoji:
## Multiple possible emoji in a row

If there are multiple possible emoji in a row, the first one is stripped:

``` ruby
io = StringIO.new("the token #1 should be unchanged")
Rumoji.encode_io(io).string
# expected: => "the token #1 should be unchanged"
# actual:   => "the token 1 should be unchanged"
```
## Last character is a possible emoji

If the last character in a string is a possible emoji, it is stripped:

``` ruby
io = StringIO.new("this character should not be stripped: 1")
Rumoji.encode_io(io).string
# expected: => "this character should not be stripped: 1"
# actual:   => "this character should not be stripped: "
```

This branch fixes both of them.
