### PR TITLE
Make decode regex work with codes that have dashes in them

### DIFF
--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -14,7 +14,7 @@ module Rumoji
 
   # Transform a cheat-sheet code into an Emoji
   def decode(str)
-    str.gsub(/:(\S?\w+):/) {|sym| Emoji.find($1.intern).to_s }
+    str.gsub(/:(\S?[\w-]+):/) {|sym| Emoji.find($1.intern).to_s }
   end
 
   def encode_io(readable, writeable=StringIO.new(""))

--- a/spec/rumoji_spec.rb
+++ b/spec/rumoji_spec.rb
@@ -9,6 +9,7 @@ describe Rumoji do
     @smile = "😄"
     @zero = "0⃣"
     @us = "🇺🇸"
+    @non_potable_water = "🚱"
   end
 
   describe "#encode" do
@@ -21,6 +22,10 @@ describe Rumoji do
   describe "#decode" do
     it "transforms a cheat-sheet code into an emoji" do
       Rumoji.decode(":poop:").must_equal @poop
+    end
+
+    it "transforms a cheat-sheet code with a dash into an emoji" do
+      Rumoji.decode(":non-potable_water:").must_equal @non_potable_water
     end
   end
 


### PR DESCRIPTION
Currently, the regex used by `Rumoji.decode` doesn’t find codes like `:non-potable_water` and they are not converted into emoji characters.
