### PR TITLE
Ignore arbitrary strings wrapped in colons

### DIFF
--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -14,7 +14,7 @@ module Rumoji
 
   # Transform a cheat-sheet code into an Emoji
   def decode(str)
-    str.gsub(/:([^s:]?[\w-]+):/) {|sym| Emoji.find($1.intern).to_s }
+    str.gsub(/:([^s:]?[\w-]+):/) {|sym| (Emoji.find($1.intern) || sym).to_s }
   end
 
   def encode_io(readable, writeable=StringIO.new(""))

--- a/spec/rumoji_spec.rb
+++ b/spec/rumoji_spec.rb
@@ -32,6 +32,10 @@ describe Rumoji do
     it "transforms a cheat-sheet code with a dash into an emoji" do
       Rumoji.decode(":non-potable_water:").must_equal @non_potable_water
     end
+    
+    it "does not transform an arbitrary string wrapped in colons" do
+      Rumoji.decode(":this-is-just-a-string:").must_equal ":this-is-just-a-string:"
+    end
   end
 
   describe "#encode_io" do


### PR DESCRIPTION
I think the attached test should say it all: Currently this gem replaces all strings that are wrapped in colons regardless if it's an emoji cheat sheet code or not.
Thanks for this great piece of software btw :+1: 