### PR TITLE
fix line brake bug

### DIFF
--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -14,7 +14,7 @@ module Rumoji
 
   # Transform a cheat-sheet code into an Emoji
   def decode(str)
-    str.gsub(/:([^s:]?[\w-]+):/) {|sym| (Emoji.find($1.intern) || sym).to_s }
+    str.gsub(/:([^\s:]?[\w-]+):/) {|sym| (Emoji.find($1.intern) || sym).to_s }
   end
 
   def encode_io(readable, writeable=StringIO.new(""))

--- a/spec/rumoji_spec.rb
+++ b/spec/rumoji_spec.rb
@@ -32,9 +32,13 @@ describe Rumoji do
     it "transforms a cheat-sheet code with a dash into an emoji" do
       Rumoji.decode(":non-potable_water:").must_equal @non_potable_water
     end
-    
+
     it "does not transform an arbitrary string wrapped in colons" do
       Rumoji.decode(":this-is-just-a-string:").must_equal ":this-is-just-a-string:"
+    end
+
+    it "transforms a cheat-sheet code into an emoji with line brake" do
+      Rumoji.decode(":\nabc:poop:").must_equal ":\nabc" + @poop
     end
   end
 


### PR DESCRIPTION
I commited wrong regexp. https://github.com/mwunsch/rumoji/commit/49caf6a0acc148ae9bbb92e0dc8c58cf4af49977

that typo `^\s` to `^s`

so can't be correctly decoded

```
":\nsometext:some-cheat-sheet-code:"
```

### related 
https://github.com/mwunsch/rumoji/pull/10
