### PR TITLE
add :simple_smile: to :smile: emoji for Slack compatibility

### DIFF
--- a/lib/rumoji/emoji/people.rb
+++ b/lib/rumoji/emoji/people.rb
@@ -6,7 +6,7 @@ require 'set'
 module Rumoji
   class Emoji
     PEOPLE = Set[
-      self.new("\u{1F604}", [:smile], "SMILING FACE WITH OPEN MOUTH AND SMILING EYES"),
+      self.new("\u{1F604}", [:smile, :simple_smile], "SMILING FACE WITH OPEN MOUTH AND SMILING EYES"),
       self.new("\u{1F606}", [:laughing], "SMILING FACE WITH OPEN MOUTH AND TIGHTLY-CLOSED EYES"),
       self.new("\u{1F60A}", [:blush], "SMILING FACE WITH SMILING EYES"),
       self.new("\u{1F603}", [:smiley], "SMILING FACE WITH OPEN MOUTH"),


### PR DESCRIPTION
I made this change a long time ago but apparently never made a PR. Slack uses `:simple_smile:` as a replacement for `:)`. This does not seem to have a standard emoji equivalent, so I added it to the regular `:smile`.