### PR TITLE
Clean emoji unicodes and markdown from string

### DIFF
--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -6,6 +6,8 @@ require 'stringio'
 module Rumoji
   extend self
 
+  MARKDOWN_REGEXP = /:([^\s:]?[\w-]+):/
+
   # Transform emoji into its cheat-sheet code
   def encode(str)
     str.gsub(Emoji::ALL_REGEXP) { |match| (emoji = Emoji.find_by_string(match)) && emoji.code || match }
@@ -13,7 +15,7 @@ module Rumoji
 
   # Transform a cheat-sheet code into an Emoji
   def decode(str)
-    str.gsub(/:([^\s:]?[\w-]+):/) { |match| (Emoji.find($1) || match).to_s }
+    str.gsub(MARKDOWN_REGEXP) { |match| (Emoji.find($1) || match).to_s }
   end
 
   def encode_io(readable, writeable=StringIO.new(""))
@@ -28,5 +30,15 @@ module Rumoji
       writeable.write decode(line)
     end
     writeable
+  end
+
+  def clean(str, types=[:markdowns, :unicodes])
+    if types.include?(:markdowns)
+      str = str.gsub(MARKDOWN_REGEXP) { |match| (Emoji.find($1) && '' || match).to_s }
+    end
+    if types.include?(:unicodes)
+      str = str.gsub(Emoji::ALL_REGEXP) { |match| Emoji.find_by_string(match) && '' || match }
+    end
+    str
   end
 end

--- a/spec/rumoji_spec.rb
+++ b/spec/rumoji_spec.rb
@@ -142,4 +142,57 @@ describe Rumoji do
       end
     end
   end
+
+  describe "#clean" do
+    it "transforms emoji into empty string" do
+      Rumoji.clean(@smile).must_equal ''
+      Rumoji.clean("#{@smile}").must_equal ''
+    end
+
+    it "transforms markdown into empty string" do
+      markdown = ':smile:'
+      Rumoji.clean(markdown).must_equal ''
+      Rumoji.clean("#{markdown}").must_equal ''
+    end
+
+    it "transforms many emoji into empty string" do
+      text = "1️⃣2️⃣3️⃣4️⃣5️⃣6️⃣7️⃣8️⃣9️⃣0️⃣#️⃣"
+      Rumoji.clean(text).must_equal ''
+      Rumoji.clean("#{text}").must_equal ''
+    end
+
+    it "transforms many markdown into empty string" do
+      text = ":one::two::three::four::five::six::seven::eight::nine::zero::hash:"
+      Rumoji.clean(text).must_equal ''
+      Rumoji.clean("#{text}").must_equal ''
+    end
+
+    it "does not transform if no unicode emoji's or markdown" do
+      text = "i like #hashtags and 1direction they are the #1 band. end with 9"
+      Rumoji.clean(text).must_equal text
+    end
+
+    describe "with emoji and markdown" do
+      it "cleans both emoji and markdown" do
+        Rumoji.clean("#{@smile} :smile:", [:markdowns, :unicodes]).must_equal ' '
+      end
+
+      it "cleans both emoji and markdown on default" do
+        Rumoji.clean("#{@smile} :smile:").must_equal ' '
+      end
+
+      it "cleans only emoji" do
+        Rumoji.clean("#{@smile} :smile:", [:unicodes]).must_equal ' :smile:'
+      end
+
+      it "cleans only markdown" do
+        Rumoji.clean("#{@smile} :smile:", [:markdowns]).must_equal "#{@smile} "
+      end
+
+      it "does not clear if empty types" do
+        both = "#{@smile} :smile:"
+        Rumoji.clean(both, []).must_equal both
+      end
+    end
+  end
 end


### PR DESCRIPTION
With this pull request:

* Ability to clean markdowns or emoji unicodes from a string


This could be used for feature based allowing\discarding emoji's\markdown from input


