### PR TITLE
Implement the ability to pass a block to encode_io and encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The symbol of the emoji surrounded with colons
 
 #### .symbol
 
-The symbol of the emoji surrounded with colons
+The symbol of the emoji
 
     Rumoji.encode("😭") {|emoji| emoji.code}
     #=> "sob"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ up being lost.
     Rumoji.encode(str)
     # Takes a String, transforms Emoji into cheat-sheet codes
 
+    Rumoji.encode(str) { |emoji| #your code here }
+    # Takes a String, transforms Emoji into whatever you want
+
     Rumoji.decode(str)
-    # Does the reverse
+    # Does the reverse of encode
 
     Rumoji.encode_io(read, write)
     # For an IO pipe (a read stream, and a write stream), transform Emoji from the
@@ -38,8 +41,10 @@ Note that rumoji has only been tested in Rubies >= 1.9!!!
 ### Some examples:
 
     puts Rumoji.encode("Lack of cross-device emoji support makes me 😭")
-
     #=> Lack of cross-device emoji support makes me :sob:
+
+    Rumoji.encode_io(StringIO.new("💩")).string
+    #=> ":poop:"
 
 Here's a fun file:
 
@@ -49,6 +54,37 @@ On the command line
 
     echo "But Rumoji makes encoding issues a :joy:" | ruby ./funfile.rb
     #=> But Rumoji makes encoding issues a 😂
+
+
+### Emoji methods
+
+#### .code
+
+The symbol of the emoji surrounded with colons
+
+    Rumoji.encode("😭") {|emoji| emoji.code}
+    #=> ":sob:"
+
+#### .symbol
+
+The symbol of the emoji surrounded with colons
+
+    Rumoji.encode("😭") {|emoji| emoji.code}
+    #=> "sob"
+
+#### .multiple?
+
+Returns true if the emoji is made up of multiple code points. E.g.  🇺🇸
+
+    Rumoji.encode("🇺🇸") {|emoji| emoji.multiple?}
+    #=> true
+
+#### .string
+
+The raw emoji
+
+    Rumoji.encode("😭") {|emoji| emoji.string}
+    #=> "😭"
 
 Implement the emoji codes from emoji-cheat-sheet.com using a tool like [gemoji](https://github.com/github/gemoji) along with Rumoji, and you'll easily be able to transform user input with raw emoji unicode into images you can show to all users.
 

--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -13,8 +13,10 @@ module Rumoji
         if block_given?
           yield emoji
         else
-          emoji.code || match
+          emoji.code
         end
+      else
+        match
       end
     end
   end

--- a/lib/rumoji.rb
+++ b/lib/rumoji.rb
@@ -8,7 +8,15 @@ module Rumoji
 
   # Transform emoji into its cheat-sheet code
   def encode(str)
-    str.gsub(Emoji::ALL_REGEXP) { |match| (emoji = Emoji.find_by_string(match)) && emoji.code || match }
+    str.gsub(Emoji::ALL_REGEXP) do |match|
+      if emoji = Emoji.find_by_string(match)
+        if block_given?
+          yield emoji
+        else
+          emoji.code || match
+        end
+      end
+    end
   end
 
   # Transform a cheat-sheet code into an Emoji
@@ -16,9 +24,9 @@ module Rumoji
     str.gsub(/:([^\s:]?[\w-]+):/) { |match| (Emoji.find($1) || match).to_s }
   end
 
-  def encode_io(readable, writeable=StringIO.new(""))
+  def encode_io(readable, writeable=StringIO.new(""), &block)
     readable.each_line do |line|
-      writeable.write encode(line)
+      writeable.write encode(line, &block)
     end
     writeable
   end

--- a/spec/rumoji_spec.rb
+++ b/spec/rumoji_spec.rb
@@ -14,7 +14,6 @@ describe Rumoji do
 
   describe "#encode" do
     it "transforms emoji into cheat-sheet form" do
-      key = :smile
       Rumoji.encode(@smile).must_equal ":smile:"
       Rumoji.encode("#{@smile}").must_equal ":smile:"
     end
@@ -54,6 +53,24 @@ describe Rumoji do
           string = "I would like 0#{@poop}"
           Rumoji.encode(string).must_equal "I would like 0:poop:"
         end
+      end
+    end
+
+    describe "when passed a block" do
+      it "calls the block" do
+        Rumoji.encode(@smile) {|emoji| emoji.symbol}.must_equal "smile"
+        Rumoji.encode("#{@smile}") {|emoji| emoji.symbol}.must_equal "smile"
+      end
+
+      it "calls the block for each emoji" do
+        symbols = [:smile, :"flag-us"]
+        result = Rumoji.encode("#{@smile}#{@us}") do |emoji|
+          assert(emoji.class == Rumoji::Emoji)
+          symbols -= [emoji.symbol]
+          emoji.symbol
+        end
+        assert_empty(symbols)
+        result.must_equal "smileflag-us"
       end
     end
   end
@@ -124,6 +141,25 @@ describe Rumoji do
           io = StringIO.new "I would like 0#{@poop}"
           Rumoji.encode_io(io).string.must_equal "I would like 0:poop:"
         end
+      end
+    end
+
+    describe "when passed a block" do
+      it "calls the block" do
+        io = StringIO.new("I like to #{@smile}")
+        Rumoji.encode_io(io) {|emoji| emoji.symbol}.string.must_equal "I like to smile"
+      end
+
+      it "calls the block for each emoji" do
+        symbols = [:smile, :"flag-us"]
+        io = StringIO.new("first emoji: #{@smile} second: #{@us}")
+        result = Rumoji.encode_io(io) do |emoji|
+          assert(emoji.class == Rumoji::Emoji)
+          symbols -= [emoji.symbol]
+          emoji.symbol
+        end
+        assert_empty(symbols)
+        result.string.must_equal "first emoji: smile second: flag-us"
       end
     end
 


### PR DESCRIPTION
This allows a library user to easily customize the representation of an
emoji (mapping it to a custom image for example)

Note: this exposes the Emoji object to the end-user (which can be very useful)

This PR isn't complete but I wanted to get the core of the code up to get some initial feedback

TODO:
- [x] docs
- [x] tests

Fixes #34